### PR TITLE
docs: add initial .repo-docs documentation

### DIFF
--- a/.repo-docs/architecture.md
+++ b/.repo-docs/architecture.md
@@ -45,7 +45,7 @@ Output (JSON/YAML/Markdown string)
 | Format | Reader | Writer | Notes |
 |--------|--------|--------|-------|
 | JSON | `JsonReader` (generic) | `JsonWriter` (generic) | Works for all model types via `ModelDTOAdapter` |
-| YAML | `YamlReader` (generic) | `YamlWriter` (generic) | Same adapter pattern as JSON |
+| YAML | `YamlReader` (generic) | `YamlWriter` (generic) | Same adapter pattern as JSON. Also used by the draw-steel-elements Obsidian plugin to deserialize YAML from markdown notes. |
 | Markdown | `MarkdownFeatureReader`, `MarkdownStatblockReader`, `MarkdownFeatureblockReader` | `MarkdownFeatureWriter`, `MarkdownStatblockWriter`, `MarkdownFeatureblockWriter` | Format-specific per model type |
 
 ### src/io/SteelCompendiumIdentifier.ts (Format Detection)

--- a/.repo-docs/architecture.md
+++ b/.repo-docs/architecture.md
@@ -1,0 +1,146 @@
+# Architecture
+
+## System Overview
+
+The SDK follows a three-layer architecture: **Model** (domain types) <-> **DTO**
+(serialization types) <-> **IO** (readers/writers). Models use camelCase and
+contain domain logic. DTOs use snake_case and map directly to JSON/YAML fields.
+IO classes handle parsing and serialization for each format.
+
+```
+Input (JSON/YAML/Markdown string)
+  --> IO layer: Reader parses string into DTO
+    --> DTO layer: DTO.toModel() converts to domain Model
+      --> Application uses Model
+    --> DTO layer: Model.toDTO() converts back
+  --> IO layer: Writer serializes DTO to string
+Output (JSON/YAML/Markdown string)
+```
+
+## Components
+
+### src/model/ (Domain Models)
+
+- **Responsibility:** Domain types with validation and conversion logic. Base class `SteelCompendiumModel` provides `read()`, `write()`, `toJson()`, `toYaml()` convenience methods.
+- **Location:** `src/model/`
+- **Depends on:** `src/dto/` (for DTO conversion)
+- **Depended on by:** `src/io/`, `src/cli/`, consumers of the npm package
+- **Key classes:** `Feature`, `Statblock`, `Featureblock`, `Effect`, `Characteristics`, `FeatureStat`
+
+### src/dto/ (Data Transfer Objects)
+
+- **Responsibility:** Flat serialization representations that map 1:1 to JSON/YAML fields. Handle snake_case <-> camelCase translation. Each DTO has `toModel()` and `partialFromModel()` static methods.
+- **Location:** `src/dto/`
+- **Depends on:** `src/model/`
+- **Depended on by:** `src/io/`
+- **Key classes:** `FeatureDTO`, `StatblockDTO`, `FeatureblockDTO`, `SteelCompendiumDTO` (base)
+
+### src/io/ (Readers and Writers)
+
+- **Responsibility:** Format-specific serialization. Abstract base classes `IDataReader<M>` and `IDataWriter<M>` define the interface. Each format has concrete implementations.
+- **Location:** `src/io/`
+- **Depends on:** `src/model/`, `src/dto/`
+- **Depended on by:** `src/cli/`, consumers of the npm package
+
+| Format | Reader | Writer | Notes |
+|--------|--------|--------|-------|
+| JSON | `JsonReader` (generic) | `JsonWriter` (generic) | Works for all model types via `ModelDTOAdapter` |
+| YAML | `YamlReader` (generic) | `YamlWriter` (generic) | Same adapter pattern as JSON |
+| Markdown | `MarkdownFeatureReader`, `MarkdownStatblockReader`, `MarkdownFeatureblockReader` | `MarkdownFeatureWriter`, `MarkdownStatblockWriter`, `MarkdownFeatureblockWriter` | Format-specific per model type |
+
+### src/io/SteelCompendiumIdentifier.ts (Format Detection)
+
+- **Responsibility:** Detect format (JSON/YAML/Markdown) and model type (Feature/Statblock/Featureblock) from input data. `parse()` uses explicit format + type. `identify()` auto-detects (unreliable).
+- **Location:** `src/io/SteelCompendiumIdentifier.ts`
+- **Depends on:** All reader classes
+- **Depended on by:** `src/cli/`, `AutoDataReader`
+
+### src/schema/ (JSON Schemas)
+
+- **Responsibility:** JSON Schema definitions for Feature and Statblock. Exported as part of the npm package.
+- **Location:** `src/schema/`
+- **Depends on:** nothing
+- **Depended on by:** `src/validation/`
+
+### src/validation/ (Schema Validator)
+
+- **Responsibility:** Ajv-based JSON Schema validation. Singleton `validator` export with `validateJSON()` method.
+- **Location:** `src/validation/`
+- **Depends on:** `src/schema/`, `ajv`
+- **Depended on by:** consumers of the npm package
+
+### src/cli/ (CLI Tool)
+
+- **Responsibility:** `sc-convert` command-line tool for batch format conversion. Parses args, detects format, reads input, writes output.
+- **Location:** `src/cli/sc-convert.ts`
+- **Depends on:** `src/io/`, `src/model/`
+- **Depended on by:** nothing (end-user entry point)
+
+## Data Flow
+
+### Reading (JSON -> Model)
+
+```
+JSON string
+  --> JsonReader.read(source)
+    --> JSON.parse(source)
+    --> ModelDTOAdapter(parsed) creates DTO
+    --> DTO.toModel() creates Model
+  --> returns Feature | Statblock | Featureblock
+```
+
+### Reading (Markdown -> Model)
+
+```
+Markdown string
+  --> MarkdownFeatureReader.read(source)
+    --> gray-matter extracts frontmatter + body
+    --> Custom parser extracts fields from blockquote/table structure
+    --> Constructs Feature directly (no DTO intermediate)
+  --> returns Feature
+```
+
+### Writing (Model -> any format)
+
+```
+Model.write(writer)
+  --> Writer.write(model)
+    --> model.toDTO() converts to DTO
+    --> Serializes DTO to target format string
+  --> returns string
+```
+
+### CLI conversion
+
+```
+sc-convert --from markdown --to json --type feature input.md --output out.json
+  --> parseArgs()
+  --> SteelCompendiumIdentifier.parse(from, type) -> reader
+  --> reader.read(fileContents) -> model
+  --> writer.write(model) -> outputString
+  --> write to file or stdout
+```
+
+## Dependencies
+
+| Dependency | Purpose | Why this one |
+|------------|---------|-------------|
+| ajv | JSON Schema validation | Industry standard JSON Schema validator for JS |
+| fast-xml-parser | XML parsing (legacy) | Still in dependencies but XML support removed in 1.0.0 |
+| gray-matter | YAML frontmatter extraction from Markdown | Standard frontmatter parser, used by Markdown readers |
+| js-yaml | YAML parsing/serialization | Mature YAML library for Node.js |
+| yaml | YAML parsing (v2) | Used alongside js-yaml for certain operations |
+| typescript | TypeScript compiler | Language of the project |
+| jest / ts-jest | Testing framework | Standard TypeScript testing stack |
+
+## Extension Points
+
+- **To add a new model type:** Create model in `src/model/`, DTO in `src/dto/`, add Markdown reader/writer in `src/io/markdown/`, register in `SteelCompendiumIdentifier.parse()`, and export from barrel files.
+- **To add a new serialization format:** Create a reader extending `IDataReader<M>` and writer extending `IDataWriter<M>` in a new `src/io/{format}/` directory. Register in `SteelCompendiumIdentifier` and update `sc-convert`.
+- **To add a new JSON Schema:** Add `.schema.json` file in `src/schema/`, register it in `src/validation/validator.ts`, and update the build script to copy it to `dist/schema/`.
+
+## Constraints
+
+- Build outputs CommonJS only (`module: commonjs` in tsconfig)
+- JSON Schemas are copied to `dist/schema/` as a post-build step (not compiled)
+- Markdown format is project-specific and not a standard -- readers/writers are tightly coupled to the Steel Compendium Markdown conventions

--- a/.repo-docs/ci-cd.md
+++ b/.repo-docs/ci-cd.md
@@ -1,0 +1,62 @@
+# CI/CD and Release
+
+## Build Process
+
+```sh
+# Full build (compiles TypeScript + copies schemas to dist/)
+npm run build
+
+# This runs: tsc && mkdir -p dist/schema && cp src/schema/*.json dist/schema/
+```
+
+### Build Artifacts
+
+| Artifact | Location | Purpose |
+|----------|----------|---------|
+| Compiled JS + type declarations | `dist/` | npm package distribution |
+| JSON Schemas | `dist/schema/` | Shipped with the npm package for consumers |
+
+## Branch Strategy
+
+| Branch | Purpose | Protection |
+|--------|---------|------------|
+| `main` | Production-ready, published code | -- |
+| Feature branches | `cli`, `featureBlock`, `format-v2`, `metadata`, `v2`, `xml` | None |
+
+No CI pipeline detected in the repo. Build and test are run manually.
+
+## Release Process
+
+### Versioning
+
+- **Scheme:** semver (2.2.0)
+- **Current version source:** `package.json` `version` field
+
+### Creating a Release
+
+Prerequisites: `NPM_PAT` environment variable must be set (see `.npmrc`).
+
+1. Ensure `git status` is clean (no uncommitted changes)
+2. Update `CHANGELOG.md` with release notes
+3. Run:
+   ```sh
+   just release <version>
+   ```
+   This does:
+   - Updates version in `package.json`
+   - Commits: `Prepares for release '<version>'`
+   - Pushes to origin
+   - Runs `npm publish`
+
+### Manual Release (without just)
+
+1. Update version in `package.json`
+2. Update `CHANGELOG.md`
+3. `git add . && git commit -m "Prepares for release '<version>'"`
+4. `git push`
+5. `npm publish`
+
+### Rollback
+
+1. `npm unpublish steel-compendium-sdk@<version>` (within 72 hours)
+2. Or publish a patch version with the fix

--- a/.repo-docs/conventions.md
+++ b/.repo-docs/conventions.md
@@ -1,0 +1,65 @@
+# Conventions
+
+## File and Directory Naming
+
+| Category | Pattern | Example |
+|----------|---------|---------|
+| Source files | PascalCase.ts | `MarkdownFeatureReader.ts` |
+| Test files | PascalCase.test.ts or PascalCase.spec.ts | `MarkdownFeatureReader.test.ts` |
+| Schema files | kebab-case.schema.json | `feature.schema.json` |
+| Test fixtures | snake_case.{json,yaml,md} | `goblin_warrior.json` |
+
+### Directory Structure Conventions
+
+- `src/io/{format}/` -- one directory per serialization format
+- `src/__tests__/` mirrors the `src/` structure
+- `src/__tests__/data/{model-type}/{format}/` -- fixture data organized by model type and format
+- Barrel `index.ts` files in each directory re-export public API
+
+## Code Style
+
+### Formatting
+
+- No formatter configured (no prettier/eslint config in repo)
+- TypeScript strict mode enabled
+
+### Language-Specific Conventions
+
+- Models use `public constructor(source: Partial<T>)` + `Object.assign(this, source)` pattern
+- Non-null assertion (`!`) used on required fields that are assigned via `Object.assign`
+- DTOs use snake_case field names to match JSON/YAML serialization
+- Models use camelCase field names
+- Abstract classes prefixed with `I` (`IDataReader`, `IDataWriter`, `IDataExtractor`)
+- Each model has a static `modelDTOAdapter` for generic reader construction
+- Base class `SteelCompendiumModel<D>` provides `read()`, `write()`, `toJson()`, `toYaml()` convenience methods
+- Singleton pattern for validator (`const validator = new Validator(); export default validator;`)
+
+## Commit Messages
+
+Pattern observed from git history:
+
+```
+<description>
+```
+
+No conventional commit prefixes used. Messages are short, imperative descriptions.
+Version preparation commits follow: `Prepares for release '<version>'`.
+
+Examples from history:
+- `Updates to support subtrait`
+- `Fixes for nested features`
+- `Adds --version flag to sc-convert (2.1.0)`
+- `Prepares for release '2.2.0'`
+
+## Naming Conventions
+
+| Entity | Convention | Example |
+|--------|-----------|---------|
+| Model classes | PascalCase noun | `Feature`, `Statblock`, `Featureblock` |
+| DTO classes | PascalCase + DTO suffix | `FeatureDTO`, `StatblockDTO` |
+| Reader/Writer classes | PascalCase + Reader/Writer | `JsonReader`, `MarkdownFeatureWriter` |
+| Model fields | camelCase | `freeStrike`, `abilityType` |
+| DTO fields | snake_case | `free_strike`, `ability_type` |
+| Enums | PascalCase | `FeatureType.Ability` |
+| Static constants | UPPER_SNAKE | `STATBLOCK_TYPE`, `FEATURE_TYPE` |
+| Type parameters | Single uppercase letter | `M extends SteelCompendiumModel<any>` |

--- a/.repo-docs/development.md
+++ b/.repo-docs/development.md
@@ -1,0 +1,138 @@
+# Development
+
+## Prerequisites
+
+| Tool | Version | Install |
+|------|---------|---------|
+| Node.js | >= 18 | https://nodejs.org/ |
+| npm | (bundled with Node) | -- |
+| just | any | https://github.com/casey/just |
+
+`just` is optional -- it's only needed for the `just release` and `just convert` helpers.
+
+## Setup
+
+1. Clone the repository:
+   ```sh
+   git clone git@github.com:SteelCompendium/data-sdk-npm.git
+   cd data-sdk-npm
+   ```
+
+2. Install dependencies:
+   ```sh
+   npm install
+   ```
+
+3. Build:
+   ```sh
+   npm run build
+   ```
+
+4. Verify setup:
+   ```sh
+   npm run test
+   ```
+
+### Required Environment Variables
+
+| Variable | Description | Required | Default |
+|----------|------------|----------|---------|
+| NPM_PAT | npm Personal Access Token for publishing | Only for `npm publish` | -- |
+
+## Common Workflows
+
+### Running Tests
+
+```sh
+npm run test
+```
+
+Or build + test together:
+```sh
+just test
+```
+
+### Running the CLI
+
+```sh
+npm run build && npm link
+sc-convert --from markdown --to json --type feature path/to/input.md --output ./tmp
+sc-convert --version
+```
+
+### Adding a New Model Type
+
+1. Create the model class in `src/model/` extending `SteelCompendiumModel`
+2. Create the DTO class in `src/dto/` extending `SteelCompendiumDTO`
+3. Create Markdown reader/writer in `src/io/markdown/`
+4. Register the new type in `SteelCompendiumIdentifier.parse()` for all three formats
+5. Export from the barrel files (`src/model/index.ts`, `src/dto/index.ts`, `src/io/markdown/index.ts`)
+6. Add test fixtures in `src/__tests__/data/{type}/` (dto-json, dto-yaml, sc-md)
+7. Add reader/writer tests in `src/__tests__/io/`
+
+### Adding a New Field to an Existing Model
+
+1. Add the field to the model class in `src/model/`
+2. Add the corresponding field to the DTO class in `src/dto/`
+3. Update `fromDTO()` and `toDTO()` / `partialFromModel()` mappings
+4. Update Markdown readers and writers to handle the new field
+5. Update test fixtures and add new test cases
+6. Update JSON Schema in `src/schema/` if applicable
+
+## Testing
+
+### Test Strategy
+
+| Type | Framework | Location | Runs on |
+|------|-----------|----------|---------|
+| Unit/Integration | Jest + ts-jest | `src/__tests__/` | local + CI |
+
+Tests are fixture-driven: each model type has test data in three formats
+(dto-json, dto-yaml, sc-md) under `src/__tests__/data/`. Tests read fixtures,
+parse them, and verify round-trip conversion.
+
+### Running Tests
+
+```sh
+# All tests
+npm run test
+
+# Specific test file
+npx jest src/__tests__/io/markdown/MarkdownFeatureReader.test.ts
+
+# Watch mode
+npx jest --watch
+```
+
+### Writing Tests
+
+- Test files go in `src/__tests__/io/` mirroring the source structure
+- Test file naming: `*.test.ts` or `*.spec.ts`
+- Fixture data goes in `src/__tests__/data/{model-type}/{format}/`
+- Tests should verify round-trip: read from one format, write to another, read back, compare
+
+### Coverage Requirements
+
+No formal coverage threshold configured, but all readers and writers should have tests.
+
+## Debugging
+
+### Common Debug Commands
+
+```sh
+# Inspect a parsed model
+npx ts-node -e "
+  const {MarkdownFeatureReader} = require('./src/io/markdown');
+  const fs = require('fs');
+  const r = new MarkdownFeatureReader();
+  console.log(JSON.stringify(r.read(fs.readFileSync('path/to/file.md','utf8')), null, 2));
+"
+
+# Validate a JSON file against schema
+npx ts-node -e "
+  const {default: validator} = require('./src/validation/validator');
+  const fs = require('fs');
+  validator.validateJSON(fs.readFileSync('path/to/file.json','utf8'), 'feature.schema.json')
+    .then(r => console.log(r));
+"
+```

--- a/.repo-docs/index.md
+++ b/.repo-docs/index.md
@@ -1,0 +1,104 @@
+---
+repo: data-sdk-npm
+type: library
+status: active
+tech:
+  - TypeScript
+  - Jest
+  - npm
+updated: 2026-04-04
+---
+
+# data-sdk-npm
+
+A TypeScript SDK for reading, writing, and converting structured Draw Steel TTRPG
+data (statblocks, features, featureblocks) between JSON, YAML, and a custom
+Markdown format. Published as the `steel-compendium-sdk` npm package and also
+provides the `sc-convert` CLI tool.
+
+**This repo is not:** a game application, a content repository, or a web frontend.
+It is a data serialization library. For the web adapter that uses this SDK, see
+[SteelCompendium/web-adapter](https://github.com/SteelCompendium/web-adapter).
+
+## Quick Reference
+
+| Action | Command |
+|--------|---------|
+| Install dependencies | `npm install` |
+| Build | `npm run build` |
+| Run tests | `npm run test` |
+| Build + test | `just test` |
+| Release a version | `just release <version>` |
+| Run CLI (after build) | `npm run build && npm link && sc-convert --from json --to yaml <file>` |
+
+| Resource | URL |
+|----------|-----|
+| npm package | https://www.npmjs.com/package/steel-compendium-sdk |
+| Issue tracker | https://github.com/SteelCompendium/data-sdk-npm/issues |
+| Bug report form | https://docs.google.com/forms/d/e/1FAIpQLSc6m-pZ0NLt2EArE-Tcxr-XbAPMyhu40ANHJKtyRvvwBd2LSw/viewform |
+
+## Repo Structure
+
+```
+data-sdk-npm/
+  src/
+    cli/                  # sc-convert CLI tool
+      sc-convert.ts
+    dto/                  # Data Transfer Objects (serialization layer)
+    io/                   # Readers and writers for each format
+      json/               #   JSON reader/writer
+      yaml/               #   YAML reader/writer
+      markdown/           #   Steel Compendium Markdown reader/writer
+      AutoDataReader.ts   #   Auto-detect format and read
+      SteelCompendiumIdentifier.ts  # Format + model type detection
+    model/                # Domain models (Feature, Statblock, Featureblock, etc.)
+    schema/               # JSON Schemas for validation
+    validation/           # Ajv-based schema validator
+    __tests__/            # Jest tests mirroring io/ structure
+      data/               # Test fixtures (JSON, YAML, Markdown per model type)
+      io/                 # Reader/writer tests
+      validation/         # Validator tests
+  dist/                   # Build output (gitignored)
+  justfile                # Task runner (release, convert helpers)
+  jest.config.js
+  tsconfig.json
+  package.json
+```
+
+## Reading Guide by Role
+
+### Human Roles
+
+| Role | Start here | Then read |
+|------|-----------|-----------|
+| **New to this repo** | This file | [project.md](project.md) |
+| **Developer** | [development.md](development.md) | [architecture.md](architecture.md), [conventions.md](conventions.md) |
+| **Architect** | [architecture.md](architecture.md) | [integration.md](integration.md) |
+
+### Agent Roles
+
+| Agent Role | Start here | Then read |
+|------------|-----------|-----------|
+| **Code review** | [conventions.md](conventions.md) | [architecture.md](architecture.md), [troubleshooting.md](troubleshooting.md) |
+| **Bug fix / debug** | [troubleshooting.md](troubleshooting.md) | [development.md](development.md), [architecture.md](architecture.md) |
+| **Feature implementation** | [architecture.md](architecture.md) | [conventions.md](conventions.md), [development.md](development.md) |
+| **Dependency update** | [integration.md](integration.md) | [architecture.md](architecture.md), [ci-cd.md](ci-cd.md) |
+| **Documentation** | This file | [project.md](project.md), [architecture.md](architecture.md) |
+
+## Current Status
+
+- **Health:** active development
+- **Last significant change:** Added subtrait support (2026-03-27, v2.2.0)
+- **Known blockers:** None
+
+## Documents in This Directory
+
+| File | Covers |
+|------|--------|
+| [project.md](project.md) | Product vision, domain context, glossary, audiences |
+| [architecture.md](architecture.md) | System design, components, data flow, dependencies |
+| [development.md](development.md) | Setup, workflows, testing, debugging |
+| [integration.md](integration.md) | Upstream/downstream dependencies, npm package surface |
+| [ci-cd.md](ci-cd.md) | Build, release process, versioning |
+| [conventions.md](conventions.md) | Code style, naming, commit messages |
+| [troubleshooting.md](troubleshooting.md) | Known issues, common errors, "Do NOT" warnings |

--- a/.repo-docs/index.md
+++ b/.repo-docs/index.md
@@ -17,8 +17,11 @@ Markdown format. Published as the `steel-compendium-sdk` npm package and also
 provides the `sc-convert` CLI tool.
 
 **This repo is not:** a game application, a content repository, or a web frontend.
-It is a data serialization library. For the web adapter that uses this SDK, see
-[SteelCompendium/web-adapter](https://github.com/SteelCompendium/web-adapter).
+It is a data serialization library. Key consumers include the
+[web-adapter](https://github.com/SteelCompendium/web-adapter) and the
+[draw-steel-elements](https://github.com/SteelCompendium/draw-steel-elements)
+Obsidian plugin (which uses the SDK's YAML reader to marshal game data embedded
+in Obsidian markdown notes).
 
 ## Quick Reference
 

--- a/.repo-docs/integration.md
+++ b/.repo-docs/integration.md
@@ -1,0 +1,67 @@
+# Integration
+
+## Dependency Map
+
+```
+                    ┌───────────────────┐
+                    │  Draw Steel TTRPG  │
+                    │  (game content)    │
+                    └────────┬──────────┘
+                             │ authored as Markdown/JSON/YAML
+                             ▼
+                    ┌───────────────────┐
+                    │ steel-compendium  │
+                    │   -sdk (this repo) │
+                    └────────┬──────────┘
+                             │ npm package
+                             ▼
+                    ┌───────────────────┐
+                    │   web-adapter     │
+                    │   (+ other tools)  │
+                    └───────────────────┘
+```
+
+## Upstream Dependencies
+
+| Source | What it provides | How we consume it | Coupling |
+|--------|-----------------|-------------------|----------|
+| Draw Steel game content | Statblocks, features, featureblocks | Authored as Markdown/JSON/YAML files passed to readers | loose (format-coupled) |
+| npm registry | Runtime dependencies (ajv, gray-matter, js-yaml, yaml) | `npm install` | standard |
+
+## Downstream Dependents
+
+| Consumer | What they use | How they consume it | Coupling |
+|----------|--------------|---------------------|----------|
+| [web-adapter](https://github.com/SteelCompendium/web-adapter) | Models, readers/writers, schemas | npm import (`steel-compendium-sdk`) | tight |
+| Community tool developers | Models, IO, validation | npm import | loose |
+| Data pipeline scripts | `sc-convert` CLI | CLI invocation | loose |
+
+## API Surface
+
+### npm Package Exports
+
+| Export path | What it provides | Stability |
+|-------------|-----------------|-----------|
+| `steel-compendium-sdk` (main) | All models, IO, DTOs, schemas, validator | stable |
+| `steel-compendium-sdk/model` | Domain models only | stable |
+| `steel-compendium-sdk/dto` | DTOs only | stable |
+| `steel-compendium-sdk/schema` | JSON Schema files | stable |
+
+### CLI
+
+| Command | Stability |
+|---------|-----------|
+| `sc-convert --from <fmt> --to <fmt> --type <type> [--output <path>] <input>` | stable |
+| `sc-convert --version` | stable |
+
+### JSON Schemas
+
+| Schema | File |
+|--------|------|
+| Feature | `dist/schema/feature.schema.json` |
+| Statblock | `dist/schema/statblock.schema.json` |
+
+## Integration Testing
+
+- **Local:** Tests use fixture files in `src/__tests__/data/` to verify round-trip conversion across all formats. No external services required.
+- **CI:** Same as local.

--- a/.repo-docs/integration.md
+++ b/.repo-docs/integration.md
@@ -14,11 +14,12 @@
                     │   -sdk (this repo) │
                     └────────┬──────────┘
                              │ npm package
-                             ▼
-                    ┌───────────────────┐
-                    │   web-adapter     │
-                    │   (+ other tools)  │
-                    └───────────────────┘
+                     ┌───────┴────────┐
+                     ▼                ▼
+            ┌──────────────┐  ┌────────────────────┐
+            │ web-adapter  │  │ draw-steel-elements │
+            │              │  │ (Obsidian plugin)   │
+            └──────────────┘  └────────────────────┘
 ```
 
 ## Upstream Dependencies
@@ -33,6 +34,7 @@
 | Consumer | What they use | How they consume it | Coupling |
 |----------|--------------|---------------------|----------|
 | [web-adapter](https://github.com/SteelCompendium/web-adapter) | Models, readers/writers, schemas | npm import (`steel-compendium-sdk`) | tight |
+| [draw-steel-elements](https://github.com/SteelCompendium/draw-steel-elements) | `YamlReader`, `Feature`, `Statblock`, `Featureblock` models | npm import (`steel-compendium-sdk`) — marshals YAML embedded in Obsidian markdown notes into domain models for plugin rendering | tight |
 | Community tool developers | Models, IO, validation | npm import | loose |
 | Data pipeline scripts | `sc-convert` CLI | CLI invocation | loose |
 

--- a/.repo-docs/project.md
+++ b/.repo-docs/project.md
@@ -55,6 +55,7 @@ Markdown format specific to the Steel Compendium project.
 | Tool developers | Read/write Draw Steel data in their apps | npm package import |
 | Data pipeline operators | Convert between formats at scale | `sc-convert` CLI |
 | Web adapter | Serialize/deserialize for web UI | npm package import (steel-compendium-sdk) |
+| draw-steel-elements Obsidian plugin | Deserialize YAML in markdown notes into domain models for rendering | npm package import — uses `YamlReader` + `Feature`, `Statblock`, `Featureblock` models |
 | Content contributors | Validate authored content | JSON Schema validation |
 
 ## Feature Inventory

--- a/.repo-docs/project.md
+++ b/.repo-docs/project.md
@@ -1,0 +1,83 @@
+# Project Context
+
+## Product Overview
+
+The Steel Compendium Data SDK is a TypeScript library for working with Draw Steel
+TTRPG game data. It provides typed models, multi-format serialization (JSON, YAML,
+Markdown), JSON Schema validation, and a CLI conversion tool. It was built so that
+community tools can programmatically read and write game content in a standardized
+format without reimplementing parsers.
+
+## Domain Context
+
+Draw Steel is a tabletop role-playing game. The game defines creatures via
+**statblocks** (stat sheets with attributes, features, and abilities) and
+character/creature capabilities via **features** (abilities, traits, and subtraits).
+Groups of features are bundled into **featureblocks**.
+
+The SDK models these game entities and handles conversion between three
+serialization formats: JSON (canonical), YAML (human-friendly), and a custom
+Markdown format specific to the Steel Compendium project.
+
+### Key Concepts
+
+- **Statblock** -- A creature's full stat sheet: name, level, roles, ancestry, stamina, speed, characteristics (might/agility/reason/intuition/presence), and a list of features.
+- **Feature** -- A single ability, trait, or subtrait. Abilities have keywords, usage, distance, target, and effects. Traits are features without those fields.
+- **Featureblock** -- A named group of features, often tied to a character class level or monster type. Has its own stats (EV, stamina, size) plus a feature list.
+- **Effect** -- Part of a feature. Can include power roll tiers (tier1/tier2/tier3/crit), named sub-effects, and nested features.
+- **Characteristics** -- The five core attributes: might, agility, reason, intuition, presence.
+- **DTO (Data Transfer Object)** -- The serialization-layer representation. DTOs map 1:1 to JSON/YAML fields (snake_case). Models are the domain-layer representation (camelCase).
+- **Steel Compendium Markdown** -- A specific Markdown format using blockquotes, bold headers, and tables to represent features and statblocks. Not generic Markdown.
+
+## Glossary
+
+| Term | Definition |
+|------|-----------|
+| ability | A feature with keywords, usage, distance, and target fields |
+| characteristics | The five core attributes of a statblock (might, agility, reason, intuition, presence) |
+| DTO | Data Transfer Object -- flat serialization representation of a model |
+| effect | A sub-element of a feature containing the mechanical outcome, optionally with power roll tiers |
+| EV | Encounter Value -- a numeric difficulty rating for statblocks and featureblocks |
+| feature | The unified model for abilities, traits, and subtraits |
+| featureblock | A named collection of features with optional stats |
+| free strike | A specific game mechanic attribute on statblocks |
+| model | The domain-layer TypeScript class (Feature, Statblock, Featureblock) |
+| power roll | A dice mechanic producing tier1/tier2/tier3/crit outcomes |
+| sc-convert | The CLI tool bundled with this SDK |
+| statblock | A creature's complete game statistics |
+| subtrait | A feature nested under another trait |
+| trait | A feature without keywords, usage, distance, or target |
+
+## Audiences
+
+| Audience | What they need | How they interact |
+|----------|---------------|-------------------|
+| Tool developers | Read/write Draw Steel data in their apps | npm package import |
+| Data pipeline operators | Convert between formats at scale | `sc-convert` CLI |
+| Web adapter | Serialize/deserialize for web UI | npm package import (steel-compendium-sdk) |
+| Content contributors | Validate authored content | JSON Schema validation |
+
+## Feature Inventory
+
+### Shipped
+
+- TypeScript domain models (Feature, Statblock, Featureblock, Effect, Characteristics)
+- JSON reader/writer (generic, works for all model types)
+- YAML reader/writer (generic, works for all model types)
+- Markdown reader/writer (format-specific per model type)
+- Auto-detection of format and model type (`SteelCompendiumIdentifier`)
+- `sc-convert` CLI for batch format conversion
+- JSON Schema validation for features and statblocks (via Ajv)
+- Subtrait support (v2.2.0)
+
+### Planned / Backlog
+
+- Update Markdown standard for final Draw Steel PDF format
+- YAML validator support
+- Additional model types (community-driven)
+
+## Constraints and Risks
+
+- **Markdown format is non-standard:** The Markdown format is specific to Steel Compendium and uses blockquotes, bold headers, and tables in a particular way. Changes to this format are breaking.
+- **Auto-identification is unreliable:** `SteelCompendiumIdentifier.identify()` has a known TODO in code noting the logic is flawed. The `parse()` method (explicit format + type) is reliable.
+- **cjs output only:** The build targets CommonJS (`module: commonjs`), which may cause issues for ESM-only consumers.

--- a/.repo-docs/troubleshooting.md
+++ b/.repo-docs/troubleshooting.md
@@ -1,0 +1,66 @@
+# Troubleshooting
+
+## Do NOT
+
+- **Do NOT** use `SteelCompendiumIdentifier.identify()` for production code -- the auto-detection logic is known to be flawed (see TODO in source). Use `SteelCompendiumIdentifier.parse(format, type)` with explicit format and type instead.
+- **Do NOT** assume Markdown format is standard Markdown -- the readers/writers expect a very specific Steel Compendium blockquote/table format. Generic Markdown will not parse.
+- **Do NOT** import from `src/` paths -- always import from the package exports (`steel-compendium-sdk`, `steel-compendium-sdk/model`, etc.)
+- **Do NOT** delete `package-lock.json` -- it's gitignored, but if present locally it keeps dependency versions stable during development.
+
+## Common Errors
+
+### `npm publish` returns 403 or 404
+
+**Cause:** The `NPM_PAT` environment variable is missing, expired, or doesn't have publish permissions.
+
+**Fix:**
+```sh
+# Generate a new PAT at https://www.npmjs.com/settings/~/tokens
+# Then set it:
+export NPM_PAT=<your-token>
+# The .npmrc file reads this variable automatically
+```
+
+### `Cannot release: 'git status' is not clean`
+
+**Cause:** The `just release` command requires a clean git working tree.
+
+**Fix:**
+```sh
+git add . && git commit -m "chore: pre-release cleanup"
+# Or stash changes:
+git stash
+just release <version>
+git stash pop
+```
+
+### Schema files missing from `dist/`
+
+**Cause:** The build step copies schemas with `cp src/schema/*.json dist/schema/`. If `dist/schema/` doesn't exist or the build was interrupted, schemas won't be present.
+
+**Fix:**
+```sh
+rm -rf dist && npm run build
+```
+
+### Markdown reader returns unexpected results
+
+**Cause:** The Markdown format is very specific. Common issues:
+- Missing frontmatter (`---` delimiters)
+- Wrong heading level (feature titles need to match expected patterns)
+- Missing blockquote markers (`>`) around statblock content
+
+**Fix:** Compare input against known-good fixtures in `src/__tests__/data/`.
+
+## FAQs
+
+### What formats does sc-convert support?
+
+JSON, YAML, and Markdown. XML was removed in v1.0.0.
+
+### How do I know which model type my data is?
+
+Check for these indicators:
+- **Statblock:** has `stamina` + `level` fields, or Markdown contains `<br>Might`
+- **Featureblock:** has `featureblock_type` field, or Markdown contains `- **EV:**`
+- **Feature:** has `effects`, `cost`, or `feature_type` fields


### PR DESCRIPTION
## Summary
- Adds comprehensive `.repo-docs/` documentation covering project overview, architecture, development workflow, CI/CD, conventions, integration, and troubleshooting
- Generated using the repo-docs skill to provide standardized project documentation

## Files Added
- `.repo-docs/index.md` — Documentation index and overview
- `.repo-docs/project.md` — Project description and goals
- `.repo-docs/architecture.md` — Architecture and code organization
- `.repo-docs/development.md` — Development setup and workflow
- `.repo-docs/ci-cd.md` — CI/CD pipeline documentation
- `.repo-docs/conventions.md` — Coding conventions and standards
- `.repo-docs/integration.md` — Integration points and dependencies
- `.repo-docs/troubleshooting.md` — Common issues and solutions

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Review documentation accuracy against current codebase